### PR TITLE
Pull request to merge minor changes into the new-osmium branch

### DIFF
--- a/importer/geombuilder.hpp
+++ b/importer/geombuilder.hpp
@@ -95,14 +95,14 @@ public:
                 geom = f->createPolygon(
                     f->createLinearRing(
                         f->getCoordinateSequenceFactory()->create(c)
-                    ).get(),
+                    ).release(),
                     nullptr
                 );
             } else {
                 // build a linestring
                 geom = f->createLineString(
                     f->getCoordinateSequenceFactory()->create(c)
-                ).get();
+                ).release();
             }
         } catch (const geos::util::GEOSException& e) {
             if (m_showerrors) {


### PR DESCRIPTION
Should use .release() to correctly transfer the ownership of the smart pointer. Pointers obtained through .get() go out of scope and cause segmentation fault (see https://github.com/osmcode/libosmium/issues/384). The modified code base now compiles with current Osmium and GEOS 3.11.5 and can properly import OSM history files (tested on Ubuntu 24.04).